### PR TITLE
Add server configuration in sergeant.yml file

### DIFF
--- a/sergeant.yml
+++ b/sergeant.yml
@@ -30,7 +30,15 @@ services:
     commandLine: ["cp", "<input", ">output"]
     synchronous: false
 
+server:
+  applicationConnectors:
+    - type: http
+      port: 9090
+  adminConnectors:
+    - type: http
+      port: 9091
 
+      
 # Logging settings.
 logging:
 


### PR DESCRIPTION
The config info for the port the server is running was missing. 

